### PR TITLE
Fix hang when recognize_song feed with less than 8ms sound

### DIFF
--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -267,6 +267,10 @@ class Shazam(Converter, Geo):
         audio = self.normalize_audio_data(song)
         signature_generator = self.create_signature_generator(audio)
         signature = signature_generator.get_next_signature()
+
+        if len(signature_generator.input_pending_processing) < 128:
+            return {'matches': []}
+
         while not signature:
             signature = signature_generator.get_next_signature()
         results = await self.send_recognize_request(signature)

--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -269,7 +269,7 @@ class Shazam(Converter, Geo):
         signature = signature_generator.get_next_signature()
 
         if len(signature_generator.input_pending_processing) < 128:
-            return {'matches': []}
+            return {"matches": []}
 
         while not signature:
             signature = signature_generator.get_next_signature()

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1,7 +1,10 @@
 import pytest_asyncio
+from pydub import AudioSegment
+from io import BytesIO
 
 from shazamio import Shazam
 from shazamio.utils import get_file_bytes
+
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -23,3 +26,17 @@ async def test_recognize_song_bytes(song_bytes: bytes):
 
     assert out.get("matches") != []
     assert out["track"]["key"] == "549679333"
+
+
+async def test_recognize_song_too_short():
+    short_audio_segment = AudioSegment.from_file(file=BytesIO(b'0'*126),
+                                                 format='pcm',
+                                                 sample_width=2,
+                                                 frame_rate=16000,
+                                                 channels=1)
+
+    shazam = Shazam()
+    out = await shazam.recognize_song(data=short_audio_segment)
+
+    assert out.get("matches") == []
+    assert "track" not in out

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -6,7 +6,6 @@ from shazamio import Shazam
 from shazamio.utils import get_file_bytes
 
 
-
 @pytest_asyncio.fixture(scope="session")
 async def song_bytes():
     yield await get_file_bytes(file="examples/data/dora.ogg")
@@ -29,11 +28,13 @@ async def test_recognize_song_bytes(song_bytes: bytes):
 
 
 async def test_recognize_song_too_short():
-    short_audio_segment = AudioSegment.from_file(file=BytesIO(b'0'*126),
-                                                 format='pcm',
-                                                 sample_width=2,
-                                                 frame_rate=16000,
-                                                 channels=1)
+    short_audio_segment = AudioSegment.from_file(
+        file=BytesIO(b"0" * 126),
+        format="pcm",
+        sample_width=2,
+        frame_rate=16000,
+        channels=1,
+    )
 
     shazam = Shazam()
     out = await shazam.recognize_song(data=short_audio_segment)


### PR DESCRIPTION
If we try to pass less than 128 samples of audio to `recognize_song()`, it will stuck forever.
This PR changes this behavior: it will return empty result immediately, assuming that it is impossible to find something recognizable in such a little audio sample.